### PR TITLE
feat: add issuer names to resolution results

### DIFF
--- a/scripts/resolve.ts
+++ b/scripts/resolve.ts
@@ -50,7 +50,9 @@ async function main(args: ReturnType<typeof parseArgs>) {
       providerUrl,
       federatedAttestationsProxyContractAddress:
         network.federatedAttestationsProxyContractAddress,
-      trustedIssuers: network.trustedIssuers,
+      // Pass in the account as a trusted issuer since we're likely using it
+      // for ad hoc testing.
+      trustedIssuers: { [account]: 'resolve-kit', ...network.trustedIssuers },
       authSigner: {
         authenticationMethod: OdisUtils.Query.AuthenticationMethod.WALLET_KEY,
         contractKit: kit,

--- a/src/resolve-celo.test.ts
+++ b/src/resolve-celo.test.ts
@@ -22,7 +22,8 @@ describe('resolve-celo', () => {
                 lookupAttestations: () => {
                   return {
                     call: () => ({
-                      accounts: ['0xf00ba7'],
+                      countsPerIssuer: ['1', '1'],
+                      accounts: ['0xf00ba7', '0xdeadf00d'],
                     }),
                   }
                 },
@@ -46,17 +47,24 @@ describe('resolve-celo', () => {
       const resolver = new ResolveCelo({
         providerUrl: 'http://does.not.matter',
         federatedAttestationsProxyContractAddress: '0x1',
-        trustedIssuers: [],
+        trustedIssuers: {
+          '0x1': 'unit-test-1',
+          '0x2': 'unit-test-2',
+        },
         authSigner,
         account: '0x3',
         serviceContext,
       })
 
       const resolutions = await resolver.resolve('+18888888888')
-      expect(resolutions.resolutions.length).toBe(1)
+      expect(resolutions.resolutions.length).toBe(2)
       expect(resolutions.errors.length).toBe(0)
-      const resolution = resolutions.resolutions[0]
-      expect(resolution.address).toBe('0xf00ba7')
+      expect(resolutions.resolutions).toEqual(
+        expect.arrayContaining([
+          { address: '0xf00ba7', issuerName: 'unit-test-1', kind: 'celo' },
+          { address: '0xdeadf00d', issuerName: 'unit-test-2', kind: 'celo' },
+        ]),
+      )
     })
 
     it('returns errors on contract call error', async () => {
@@ -93,7 +101,7 @@ describe('resolve-celo', () => {
       const resolver = new ResolveCelo({
         providerUrl: 'http://does.not.matter',
         federatedAttestationsProxyContractAddress: '0x1',
-        trustedIssuers: [],
+        trustedIssuers: { '0x2': 'unit-test' },
         authSigner,
         account: '0x3',
         serviceContext,
@@ -130,7 +138,7 @@ describe('resolve-celo', () => {
       const resolver = new ResolveCelo({
         providerUrl: 'http://does.not.matter',
         federatedAttestationsProxyContractAddress: '0x1',
-        trustedIssuers: [],
+        trustedIssuers: { '0x2': 'unit-test' },
         authSigner,
         account: '0x3',
         serviceContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,17 @@ export enum ResolutionKind {
 }
 
 export interface NameResolution {
+  // Method of resolution
   kind: ResolutionKind
+  // Address of resolution
   address: Address
+  // Name of entity that created the resolution. For example, 'Kaala' might
+  // create a resolution on SocialConnect.
+  issuerName?: string
+  // The resolve method might perform some normalization on the ID passed in.
+  // This is the result of that normalization.
   name?: string
+  // TODO: remove?
   thumbnailPath?: string
 }
 


### PR DESCRIPTION
Clients can surface this information to users (e.g., "send to 0xf00 on Kaala").