### PR TITLE
chore: downgrade @celo/contractkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "build:scripts": "tsc --project scripts/tsconfig.json",
+    "typecheck": "yarn build && yarn build:scripts",
     "lint": "eslint --ext=.tsx,.ts,.json --fix src/ scripts/",
     "format": "prettier --loglevel error --write .",
-    "test": "jest --coverage && prettier --check \"./**/*.ts\" && eslint --ext=.tsx,.ts,.json src/ scripts/",
+    "test": "yarn typecheck && jest --coverage && prettier --check \"./**/*.ts\" && eslint --ext=.tsx,.ts,.json src/ scripts/",
     "prepublish": "rm -rf dist && tsc",
     "release": "npx semantic-release",
     "resolve": "ts-node --files=src/global.d.ts scripts/resolve.ts"
@@ -20,7 +22,7 @@
   "license": "Apache-2.0",
   "prettier": "@valora/prettier-config",
   "devDependencies": {
-    "@celo/contractkit": "^6.0.0",
+    "@celo/contractkit": "^5.2.1",
     "@types/jest": "^29.5.11",
     "@types/node": "^17.0.45",
     "@typescript-eslint/eslint-plugin": "^6.17.0",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["es2021"],
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["*.ts", "../src/global.d.ts"]
+}


### PR DESCRIPTION
So types are compatible with @celo/identity. @celo/contractkit is in devDependencies, and future work will work to move us off it.

Add CI to prevent automatic upgrades.