### PR TITLE
fix: masa throwing error during name resolution

### DIFF
--- a/src/resolve-masa.test.ts
+++ b/src/resolve-masa.test.ts
@@ -1,6 +1,6 @@
 import { ResolveMasa } from './resolve-masa'
 import { Masa } from '@masa-finance/masa-sdk'
-import { providers } from 'ethers'
+import { VoidSigner, constants, providers } from 'ethers'
 
 jest.mock('@masa-finance/masa-sdk')
 
@@ -33,7 +33,10 @@ describe('masa', () => {
     }))
 
     const masa = new Masa({
-      signer: new providers.JsonRpcProvider().getSigner(),
+      signer: new VoidSigner(
+        constants.AddressZero,
+        new providers.JsonRpcProvider(),
+      ),
       networkName: 'alfajores',
     })
 

--- a/src/resolve-masa.ts
+++ b/src/resolve-masa.ts
@@ -1,6 +1,6 @@
 import { NameResolutionResults, NameResolver, ResolutionKind } from './types'
 
-import { providers } from 'ethers'
+import { VoidSigner, constants, providers } from 'ethers'
 import { Masa } from '@masa-finance/masa-sdk'
 
 export class ResolveMasa implements NameResolver {
@@ -18,7 +18,10 @@ export class ResolveMasa implements NameResolver {
     this.masa = masa
       ? masa
       : new Masa({
-          signer: new providers.JsonRpcProvider(providerUrl).getSigner(),
+          signer: new VoidSigner(
+            constants.AddressZero,
+            new providers.JsonRpcProvider(providerUrl),
+          ),
           networkName: networkName === 'mainnet' ? 'celo' : 'alfajores',
         })
   }


### PR DESCRIPTION
Masa is throwing an error during `.celo` name resolution because we provided it with the signer without any addresses.

Instead, we can provide it with a [VoidSigner](https://docs.ethers.org/v5/api/signer/#VoidSigner) with a zero-address, because we are interacting only with contracts public methods.

#### Context

Valora REST API returns an error while resolving a valid Masa address:

https://api.mainnet.valora.xyz/resolveId?id=jean.celo

Response:
```
{
  "resolutions": [],
  "errors": [
    {
      "kind": "masa",
      "message": "unknown account #0 (operation=\"getAddress\", code=UNSUPPORTED_OPERATION, version=providers/5.7.2)"
    }
  ]
}
```